### PR TITLE
Update smtp2mqtt.py

### DIFF
--- a/smtp2mqtt/CHANGELOG.md
+++ b/smtp2mqtt/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.0.4] - 2024-06-24
+
+### Changed
+
+- Added default error handling for getting "content" from "mime_part" to account for crash due to unexpected mime type.
+
 ## [1.0.3] - 2023-02-27
 
 ### Changed

--- a/smtp2mqtt/config.yaml
+++ b/smtp2mqtt/config.yaml
@@ -2,7 +2,7 @@
 name: "SMTP to MQTT"
 description: "A simple, tiny, absolutely no-frills Python-based SMTP server that publishes mail to an MQTT topic then (optionally) passes the mail on to the next relay"
 url: "https://github.com/bcastellucci/addons"
-version: "1.0.3"
+version: "1.0.4"
 slug: "smtp2mqtt"
 arch:
   - aarch64

--- a/smtp2mqtt/smtp2mqtt.py
+++ b/smtp2mqtt/smtp2mqtt.py
@@ -96,7 +96,10 @@ class SMTP2MQTTHandler:
         for header in msgBody.items():
             mime_part['headers'][header[0].lower()] = header[1]
             if (log.isEnabledFor(logging.DEBUG)): log.debug("got body header %s: %s", header[0], header[1], extra=log_extra)
-        mime_part['content'] = msgBody.get_content()
+        try:
+            mime_part['content'] = msgBody.get_content()
+        except:
+            mime_part['content'] = ""
         if (log.isEnabledFor(logging.DEBUG)): log.debug("stored [%s] as the content", mime_part['content'], extra=log_extra)
         payload['mime_parts'].append(mime_part)
 


### PR DESCRIPTION
Added default error handling for getting "content" from "mime_part" to account for crash due to unexpected mime type.

Messages sent using one of my devices apparently has a section with a mime-type of "multipart/related", which the mail server library used does not know how to handle, resulting in `500 Error: (KeyError) 'multipart/related'`.  This PR adds a basic try/except and sets the value of multi_part['content'] to "" if parsing fails.
