### PR TITLE
feat: Added handle_HELO to process non-standard communication as exte…

### DIFF
--- a/smtp2mqtt/smtp2mqtt.py
+++ b/smtp2mqtt/smtp2mqtt.py
@@ -146,6 +146,13 @@ class SMTP2MQTTHandler:
         # done!
         return "250 Message accepted for delivery"
 
+    async def handle_HELO(self, server, session, envelope, hostname):
+        # Set extended SMTP (ESMTP)
+        session.extended_smtp = True
+        log.debug(f"HELO received from {hostname}, extended SMTP enabled", extra={'uuid': 'main thread'})
+        session.host_name = hostname
+        return '250 {}'.format(server.hostname)
+
     def mqtt_publish(self, topic, payload, log_extra):
         if config["DEBUG"]:
             if (log.isEnabledFor(logging.DEBUG)): log.debug('Publishing [%s] to %s', payload, topic, extra=log_extra)


### PR DESCRIPTION
Added handle_HELO to process non-standard communication as extended SMTP

- Modified smtp2mqtt.py to handle HELO from devices with non-RFC compliant behavior.
- Updated to ensure compatibility with DVR Slinex GL-08N, which sends non-standard SMTP commands.

Closes #3